### PR TITLE
Allow SMILES structures fewer than 7 characters long

### DIFF
--- a/src/coffee/main.coffee
+++ b/src/coffee/main.coffee
@@ -115,7 +115,7 @@ $(document).ready ->
   # @param [function] fail    the failure callback
   #
   checkSmiles = (smiles, success, fail) ->
-    regex = /^([^J][a-z0-9@+\-\[\]\(\)\\\/%=#$]{6,})$/ig
+    regex = /^([^J][a-z0-9@+\-\[\]\(\)\\\/%=#$]{0,})$/ig
     if regex.test smiles then success() else fail()
 
   # Actions to take when we refresh the preview.


### PR DESCRIPTION
The regular expression in the CoffeeScript that validates SMILES structures has a lower limit on length (7 or longer accepted, others rejected).

This PR changes this regular expression to allow SMILES structures of 1 character or more.