### PR TITLE
Add parameter to expand burger menu by default

### DIFF
--- a/src/coffee/hamburger.coffee
+++ b/src/coffee/hamburger.coffee
@@ -16,7 +16,8 @@
 # Converted to CoffeeScript and modified by Saul Johnson (@lambdacasserole).
 
 $(document).ready ->
-  trigger = $('.hamburger')
+  trigger = $ '.hamburger'
+  wrapper = $ '#wrapper'
   isClosed = false
 
   hamburger_cross = ->
@@ -29,8 +30,16 @@ $(document).ready ->
       trigger.addClass 'is-open'
       isClosed = true
 
+  toggle_open = ->
+    wrapper.toggleClass 'toggled'
+    hamburger_cross()
+
   trigger.click ->
     hamburger_cross()
     
   $('[data-toggle="offcanvas"]').click ->
-    $('#wrapper').toggleClass 'toggled'
+    wrapper.toggleClass 'toggled'
+
+  # Expand burger menu if URL asks for it.
+  if getParameterByName('showmenu') == 'true'
+    toggle_open()

--- a/src/coffee/params.coffee
+++ b/src/coffee/params.coffee
@@ -1,0 +1,16 @@
+# Gets the value of a parameter passed to the page via a query string.
+#
+# @param [string] name  the name of the parameter to get the value of
+# @param [string] url   the URL to parse the query string from, default to `window.location.href`
+#
+window.getParameterByName = (name, url) ->
+  if !url
+    url = window.location.href
+  name = name.replace(/[\[\]]/g, '\\$&')
+  regex = new RegExp('[?&]' + name + '(=([^&#]*)|&|#|$)')
+  results = regex.exec(url)
+  if !results
+    return null
+  if !results[2]
+    return ''
+  decodeURIComponent results[2].replace(/\+/g, ' ')

--- a/templates/index.html.twig
+++ b/templates/index.html.twig
@@ -31,6 +31,7 @@
         <script type="text/javascript" src="/bower_components/jquery/dist/jquery.min.js"></script>
         <script type="text/javascript" src="/bower_components/bootstrap/dist/js/bootstrap.min.js"></script>
         <script type="text/javascript" src="/bower_components/spectrum/spectrum.js"></script>
+        <script type="text/javascript" src="/js/params.js"></script>
         <script type="text/javascript" src="/js/hamburger.js"></script>
         <script type="text/javascript" src="/js/main.js"></script>
         {% include "_analytics.html.twig" %}


### PR DESCRIPTION
If `showmenu=true` is added to the URL the burger menu will be expanded by default. This should make it harder to miss the menu.