### PR TITLE
Handle spaces in URLs safely

### DIFF
--- a/src/MoleculeRenderer.php
+++ b/src/MoleculeRenderer.php
@@ -51,10 +51,10 @@ class MoleculeRenderer
     {
         // Proxy into Sourire for molecule render.
         $img = Image::make($this->sourireUrl 
-            . 'molecule/' . urlencode($smiles) 
+            . 'molecule/' . rawurlencode($smiles) 
             . '?render-stereo-style=' . ($this->renderChiralLabels ? 'old' : 'none') // Label chiral atoms?
             . '&render-comment-offset=16' // Give some space between label and molecule.
-            . ($this->customLabel === '' ? '' : ('&render-comment=' . urlencode($this->customLabel))));
+            . ($this->customLabel === '' ? '' : ('&render-comment=' . rawurlencode($this->customLabel))));
 
         // Colorize molecule.
         list($r, $g, $b) = sscanf($color, "%02x%02x%02x");

--- a/src/SmilesConverter.php
+++ b/src/SmilesConverter.php
@@ -48,7 +48,7 @@ class SmilesConverter
     public function nameToSmiles($name)
     {
         // Sanitize name for URLs.
-        $encoded = urlencode($name);
+        $encoded = rawurlencode($name);
 
         // Check if we've got the name cached already.
         if ($this->isCacheEnabled()) {

--- a/src/coffee/main.coffee
+++ b/src/coffee/main.coffee
@@ -34,7 +34,7 @@ $(document).ready ->
   # Gets the sanitized compound name as entered by the user.
   #
   getCompoundName = ->
-    encodeURIComponent compoundTextBox.val().replace(/\s/g, '')
+    encodeURIComponent compoundTextBox.val()
 
   # Gets the sanitized compound SMILES structure as entered by the user.
   #


### PR DESCRIPTION
We were removing spaces instead of just URL-encoding them in the CoffeeScript on the client side. Then on the server side we were encoding them to `+` rather than `%20` which was messing with some external APIs. This should allow the app to render molecules like `methyl orange` and `denatonium benzoate` without an issue.