### PR TITLE
Restructure SMILES lookup services into chain of responsibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
         "mustangostang/spyc": "^0.5.1",
         "intervention/image": "^2.4",
         "guzzlehttp/guzzle": "^6.3",
-        "lambdacasserole/condense": "^1.1"
+        "lambdacasserole/condense": "^1.1",
+        "tburry/pquery": "^1.1"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "mustangostang/spyc": "^0.5.1",
         "intervention/image": "^2.4",
         "guzzlehttp/guzzle": "^6.3",
-        "lambdacasserole/condense": "^1.1",
+        "lambdacasserole/condense": "^1.2",
         "tburry/pquery": "^1.1"
     },
     "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "18fab38459b21165a1075c73d836e92c",
+    "content-hash": "82f30d1a5607b0db9092eb88a3f265ea",
     "packages": [
         {
             "name": "defuse/php-encryption",
@@ -322,16 +322,16 @@
         },
         {
             "name": "lambdacasserole/condense",
-            "version": "v1.1",
+            "version": "v1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/lambdacasserole/condense.git",
-                "reference": "dcbe8d7ca5ee0909a0df7c47e493311d130cbe9d"
+                "reference": "8590a14206f60c7e01f4fe6c5ca94260b781f81e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/lambdacasserole/condense/zipball/dcbe8d7ca5ee0909a0df7c47e493311d130cbe9d",
-                "reference": "dcbe8d7ca5ee0909a0df7c47e493311d130cbe9d",
+                "url": "https://api.github.com/repos/lambdacasserole/condense/zipball/8590a14206f60c7e01f4fe6c5ca94260b781f81e",
+                "reference": "8590a14206f60c7e01f4fe6c5ca94260b781f81e",
                 "shasum": ""
             },
             "require": {
@@ -354,7 +354,7 @@
                 }
             ],
             "description": "Flat-file database in PHP.",
-            "time": "2017-01-30T14:35:04+00:00"
+            "time": "2017-08-27T17:51:51+00:00"
         },
         {
             "name": "mustangostang/spyc",
@@ -453,25 +453,29 @@
         },
         {
             "name": "pimple/pimple",
-            "version": "v3.0.2",
+            "version": "v3.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/silexphp/Pimple.git",
-                "reference": "a30f7d6e57565a2e1a316e1baf2a483f788b258a"
+                "reference": "4d45fb62d96418396ec58ba76e6f065bca16e10a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/silexphp/Pimple/zipball/a30f7d6e57565a2e1a316e1baf2a483f788b258a",
-                "reference": "a30f7d6e57565a2e1a316e1baf2a483f788b258a",
+                "url": "https://api.github.com/repos/silexphp/Pimple/zipball/4d45fb62d96418396ec58ba76e6f065bca16e10a",
+                "reference": "4d45fb62d96418396ec58ba76e6f065bca16e10a",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.0"
+                "php": ">=5.3.0",
+                "psr/container": "^1.0"
+            },
+            "require-dev": {
+                "symfony/phpunit-bridge": "^3.2"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0.x-dev"
+                    "dev-master": "3.2.x-dev"
                 }
             },
             "autoload": {
@@ -495,7 +499,56 @@
                 "container",
                 "dependency injection"
             ],
-            "time": "2015-09-11T15:10:35+00:00"
+            "time": "2017-07-23T07:32:15+00:00"
+        },
+        {
+            "name": "psr/container",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/container.git",
+                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
+                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Container\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common Container Interface (PHP FIG PSR-11)",
+            "homepage": "https://github.com/php-fig/container",
+            "keywords": [
+                "PSR-11",
+                "container",
+                "container-interface",
+                "container-interop",
+                "psr"
+            ],
+            "time": "2017-02-14T16:28:37+00:00"
         },
         {
             "name": "psr/http-message",
@@ -549,22 +602,30 @@
         },
         {
             "name": "psr/log",
-            "version": "1.0.0",
+            "version": "1.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/log.git",
-                "reference": "fe0936ee26643249e916849d48e3a51d5f5e278b"
+                "reference": "4ebe3a8bf773a19edfe0a84b6585ba3d401b724d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/fe0936ee26643249e916849d48e3a51d5f5e278b",
-                "reference": "fe0936ee26643249e916849d48e3a51d5f5e278b",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/4ebe3a8bf773a19edfe0a84b6585ba3d401b724d",
+                "reference": "4ebe3a8bf773a19edfe0a84b6585ba3d401b724d",
                 "shasum": ""
             },
+            "require": {
+                "php": ">=5.3.0"
+            },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
             "autoload": {
-                "psr-0": {
-                    "Psr\\Log\\": ""
+                "psr-4": {
+                    "Psr\\Log\\": "Psr/Log/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -578,25 +639,26 @@
                 }
             ],
             "description": "Common interface for logging libraries",
+            "homepage": "https://github.com/php-fig/log",
             "keywords": [
                 "log",
                 "psr",
                 "psr-3"
             ],
-            "time": "2012-12-21T11:40:51+00:00"
+            "time": "2016-10-10T12:19:37+00:00"
         },
         {
             "name": "silex/silex",
-            "version": "v2.0.2",
+            "version": "v2.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/silexphp/Silex.git",
-                "reference": "7420ac96195ea7eb6f1e11dc273be49359dd50ad"
+                "reference": "ec7d5b5334465414952d4b2e935e73bd085dbbbb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/silexphp/Silex/zipball/7420ac96195ea7eb6f1e11dc273be49359dd50ad",
-                "reference": "7420ac96195ea7eb6f1e11dc273be49359dd50ad",
+                "url": "https://api.github.com/repos/silexphp/Silex/zipball/ec7d5b5334465414952d4b2e935e73bd085dbbbb",
+                "reference": "ec7d5b5334465414952d4b2e935e73bd085dbbbb",
                 "shasum": ""
             },
             "require": {
@@ -606,6 +668,9 @@
                 "symfony/http-foundation": "~2.8|^3.0",
                 "symfony/http-kernel": "~2.8|^3.0",
                 "symfony/routing": "~2.8|^3.0"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<4.8.35 || >= 5.0, <5.4.3"
             },
             "replace": {
                 "silex/api": "self.version",
@@ -628,7 +693,7 @@
                 "symfony/intl": "~2.8|^3.0",
                 "symfony/monolog-bridge": "~2.8|^3.0",
                 "symfony/options-resolver": "~2.8|^3.0",
-                "symfony/phpunit-bridge": "~2.8|^3.0",
+                "symfony/phpunit-bridge": "^3.2",
                 "symfony/process": "~2.8|^3.0",
                 "symfony/security": "~2.8|^3.0",
                 "symfony/serializer": "~2.8|^3.0",
@@ -636,12 +701,13 @@
                 "symfony/twig-bridge": "~2.8|^3.0",
                 "symfony/validator": "~2.8|^3.0",
                 "symfony/var-dumper": "~2.8|^3.0",
-                "twig/twig": "~1.8|~2.0"
+                "symfony/web-link": "^3.3",
+                "twig/twig": "~1.28|~2.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "2.2.x-dev"
                 }
             },
             "autoload": {
@@ -668,20 +734,20 @@
             "keywords": [
                 "microframework"
             ],
-            "time": "2016-06-14T09:27:51+00:00"
+            "time": "2017-07-23T07:40:14+00:00"
         },
         {
             "name": "symfony/debug",
-            "version": "v3.1.2",
+            "version": "v3.3.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/debug.git",
-                "reference": "06e2d52e307ef880ac739f44ee6c2418ca9e3283"
+                "reference": "7c13ae8ce1e2adbbd574fc39de7be498e1284e13"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/debug/zipball/06e2d52e307ef880ac739f44ee6c2418ca9e3283",
-                "reference": "06e2d52e307ef880ac739f44ee6c2418ca9e3283",
+                "url": "https://api.github.com/repos/symfony/debug/zipball/7c13ae8ce1e2adbbd574fc39de7be498e1284e13",
+                "reference": "7c13ae8ce1e2adbbd574fc39de7be498e1284e13",
                 "shasum": ""
             },
             "require": {
@@ -692,13 +758,12 @@
                 "symfony/http-kernel": ">=2.3,<2.3.24|~2.4.0|>=2.5,<2.5.9|>=2.6,<2.6.2"
             },
             "require-dev": {
-                "symfony/class-loader": "~2.8|~3.0",
                 "symfony/http-kernel": "~2.8|~3.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1-dev"
+                    "dev-master": "3.3-dev"
                 }
             },
             "autoload": {
@@ -725,29 +790,32 @@
             ],
             "description": "Symfony Debug Component",
             "homepage": "https://symfony.com",
-            "time": "2016-06-29T05:41:56+00:00"
+            "time": "2017-07-28T15:27:31+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v3.1.2",
+            "version": "v3.3.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "7f9839ede2070f53e7e2f0849b9bd14748c434c5"
+                "reference": "67535f1e3fd662bdc68d7ba317c93eecd973617e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/7f9839ede2070f53e7e2f0849b9bd14748c434c5",
-                "reference": "7f9839ede2070f53e7e2f0849b9bd14748c434c5",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/67535f1e3fd662bdc68d7ba317c93eecd973617e",
+                "reference": "67535f1e3fd662bdc68d7ba317c93eecd973617e",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.5.9"
             },
+            "conflict": {
+                "symfony/dependency-injection": "<3.3"
+            },
             "require-dev": {
                 "psr/log": "~1.0",
                 "symfony/config": "~2.8|~3.0",
-                "symfony/dependency-injection": "~2.8|~3.0",
+                "symfony/dependency-injection": "~3.3",
                 "symfony/expression-language": "~2.8|~3.0",
                 "symfony/stopwatch": "~2.8|~3.0"
             },
@@ -758,7 +826,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1-dev"
+                    "dev-master": "3.3-dev"
                 }
             },
             "autoload": {
@@ -785,20 +853,20 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
-            "time": "2016-06-29T05:41:56+00:00"
+            "time": "2017-06-09T14:53:08+00:00"
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v3.1.2",
+            "version": "v3.3.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "6b5a3764c5b0ce1f0ec3b8be5bba969122a78cfc"
+                "reference": "49e8cd2d59a7aa9bfab19e46de680c76e500a031"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/6b5a3764c5b0ce1f0ec3b8be5bba969122a78cfc",
-                "reference": "6b5a3764c5b0ce1f0ec3b8be5bba969122a78cfc",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/49e8cd2d59a7aa9bfab19e46de680c76e500a031",
+                "reference": "49e8cd2d59a7aa9bfab19e46de680c76e500a031",
                 "shasum": ""
             },
             "require": {
@@ -811,7 +879,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1-dev"
+                    "dev-master": "3.3-dev"
                 }
             },
             "autoload": {
@@ -838,20 +906,20 @@
             ],
             "description": "Symfony HttpFoundation Component",
             "homepage": "https://symfony.com",
-            "time": "2016-06-29T07:02:31+00:00"
+            "time": "2017-07-21T11:04:46+00:00"
         },
         {
             "name": "symfony/http-kernel",
-            "version": "v3.1.2",
+            "version": "v3.3.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "3a1ce1829128988826739bd9dd820f3238b92d65"
+                "reference": "db10d05f1d95e4168e638db7a81c79616f568ea5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/3a1ce1829128988826739bd9dd820f3238b92d65",
-                "reference": "3a1ce1829128988826739bd9dd820f3238b92d65",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/db10d05f1d95e4168e638db7a81c79616f568ea5",
+                "reference": "db10d05f1d95e4168e638db7a81c79616f568ea5",
                 "shasum": ""
             },
             "require": {
@@ -859,18 +927,22 @@
                 "psr/log": "~1.0",
                 "symfony/debug": "~2.8|~3.0",
                 "symfony/event-dispatcher": "~2.8|~3.0",
-                "symfony/http-foundation": "~2.8.8|~3.0.8|~3.1.2|~3.2"
+                "symfony/http-foundation": "~3.3"
             },
             "conflict": {
-                "symfony/config": "<2.8"
+                "symfony/config": "<2.8",
+                "symfony/dependency-injection": "<3.3",
+                "symfony/var-dumper": "<3.3",
+                "twig/twig": "<1.34|<2.4,>=2"
             },
             "require-dev": {
+                "psr/cache": "~1.0",
                 "symfony/browser-kit": "~2.8|~3.0",
                 "symfony/class-loader": "~2.8|~3.0",
                 "symfony/config": "~2.8|~3.0",
                 "symfony/console": "~2.8|~3.0",
                 "symfony/css-selector": "~2.8|~3.0",
-                "symfony/dependency-injection": "~2.8|~3.0",
+                "symfony/dependency-injection": "~3.3",
                 "symfony/dom-crawler": "~2.8|~3.0",
                 "symfony/expression-language": "~2.8|~3.0",
                 "symfony/finder": "~2.8|~3.0",
@@ -879,7 +951,7 @@
                 "symfony/stopwatch": "~2.8|~3.0",
                 "symfony/templating": "~2.8|~3.0",
                 "symfony/translation": "~2.8|~3.0",
-                "symfony/var-dumper": "~2.8|~3.0"
+                "symfony/var-dumper": "~3.3"
             },
             "suggest": {
                 "symfony/browser-kit": "",
@@ -893,7 +965,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1-dev"
+                    "dev-master": "3.3-dev"
                 }
             },
             "autoload": {
@@ -920,20 +992,20 @@
             ],
             "description": "Symfony HttpKernel Component",
             "homepage": "https://symfony.com",
-            "time": "2016-06-30T17:16:01+00:00"
+            "time": "2017-08-01T10:25:59+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.2.0",
+            "version": "v1.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "dff51f72b0706335131b00a7f49606168c582594"
+                "reference": "7c8fae0ac1d216eb54349e6a8baa57d515fe8803"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/dff51f72b0706335131b00a7f49606168c582594",
-                "reference": "dff51f72b0706335131b00a7f49606168c582594",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/7c8fae0ac1d216eb54349e6a8baa57d515fe8803",
+                "reference": "7c8fae0ac1d216eb54349e6a8baa57d515fe8803",
                 "shasum": ""
             },
             "require": {
@@ -945,7 +1017,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.2-dev"
+                    "dev-master": "1.5-dev"
                 }
             },
             "autoload": {
@@ -979,36 +1051,39 @@
                 "portable",
                 "shim"
             ],
-            "time": "2016-05-18T14:26:46+00:00"
+            "time": "2017-06-14T15:44:48+00:00"
         },
         {
             "name": "symfony/routing",
-            "version": "v3.1.2",
+            "version": "v3.3.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/routing.git",
-                "reference": "22c7adc204057a0ff0b12eea2889782a5deb70a3"
+                "reference": "4aee1a917fd4859ff8b51b9fd1dfb790a5ecfa26"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/routing/zipball/22c7adc204057a0ff0b12eea2889782a5deb70a3",
-                "reference": "22c7adc204057a0ff0b12eea2889782a5deb70a3",
+                "url": "https://api.github.com/repos/symfony/routing/zipball/4aee1a917fd4859ff8b51b9fd1dfb790a5ecfa26",
+                "reference": "4aee1a917fd4859ff8b51b9fd1dfb790a5ecfa26",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.5.9"
             },
             "conflict": {
-                "symfony/config": "<2.8"
+                "symfony/config": "<2.8",
+                "symfony/dependency-injection": "<3.3",
+                "symfony/yaml": "<3.3"
             },
             "require-dev": {
                 "doctrine/annotations": "~1.0",
                 "doctrine/common": "~2.2",
                 "psr/log": "~1.0",
                 "symfony/config": "~2.8|~3.0",
+                "symfony/dependency-injection": "~3.3",
                 "symfony/expression-language": "~2.8|~3.0",
                 "symfony/http-foundation": "~2.8|~3.0",
-                "symfony/yaml": "~2.8|~3.0"
+                "symfony/yaml": "~3.3"
             },
             "suggest": {
                 "doctrine/annotations": "For using the annotation loader",
@@ -1021,7 +1096,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1-dev"
+                    "dev-master": "3.3-dev"
                 }
             },
             "autoload": {
@@ -1054,7 +1129,7 @@
                 "uri",
                 "url"
             ],
-            "time": "2016-06-29T05:41:56+00:00"
+            "time": "2017-07-21T17:43:13+00:00"
         },
         {
             "name": "tburry/pquery",
@@ -1110,34 +1185,38 @@
         },
         {
             "name": "twig/twig",
-            "version": "v1.24.1",
+            "version": "v1.34.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/Twig.git",
-                "reference": "3566d311a92aae4deec6e48682dc5a4528c4a512"
+                "reference": "f878bab48edb66ad9c6ed626bf817f60c6c096ee"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/3566d311a92aae4deec6e48682dc5a4528c4a512",
-                "reference": "3566d311a92aae4deec6e48682dc5a4528c4a512",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/f878bab48edb66ad9c6ed626bf817f60c6c096ee",
+                "reference": "f878bab48edb66ad9c6ed626bf817f60c6c096ee",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.2.7"
+                "php": ">=5.3.3"
             },
             "require-dev": {
+                "psr/container": "^1.0",
                 "symfony/debug": "~2.7",
-                "symfony/phpunit-bridge": "~2.7"
+                "symfony/phpunit-bridge": "~3.3@dev"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.24-dev"
+                    "dev-master": "1.34-dev"
                 }
             },
             "autoload": {
                 "psr-0": {
                     "Twig_": "lib/"
+                },
+                "psr-4": {
+                    "Twig\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -1167,7 +1246,7 @@
             "keywords": [
                 "templating"
             ],
-            "time": "2016-05-30T09:11:59+00:00"
+            "time": "2017-07-04T13:19:31+00:00"
         }
     ],
     "packages-dev": [],

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "414181a9b439757b16b4938d109a80bd",
+    "content-hash": "18fab38459b21165a1075c73d836e92c",
     "packages": [
         {
             "name": "defuse/php-encryption",
@@ -1055,6 +1055,58 @@
                 "url"
             ],
             "time": "2016-06-29T05:41:56+00:00"
+        },
+        {
+            "name": "tburry/pquery",
+            "version": "v1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/tburry/pquery.git",
+                "reference": "872339ffd38d261c4417ea1855428b1b4ff9abf1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/tburry/pquery/zipball/872339ffd38d261c4417ea1855428b1b4ff9abf1",
+                "reference": "872339ffd38d261c4417ea1855428b1b4ff9abf1",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "htmlawed/htmlawed": "dev-master"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "IQuery.php",
+                    "gan_formatter.php",
+                    "gan_node_html.php",
+                    "gan_parser_html.php",
+                    "gan_selector_html.php",
+                    "gan_tokenizer.php",
+                    "gan_xml2array.php",
+                    "pQuery.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-2.1"
+            ],
+            "authors": [
+                {
+                    "name": "Todd Burry",
+                    "email": "todd@vanillaforums.com",
+                    "role": "developer"
+                }
+            ],
+            "description": "A jQuery like html dom parser written in php.",
+            "keywords": [
+                "dom",
+                "ganon",
+                "php"
+            ],
+            "time": "2016-01-14T20:55:00+00:00"
         },
         {
             "name": "twig/twig",

--- a/src/CactusSmilesConverter.php
+++ b/src/CactusSmilesConverter.php
@@ -33,7 +33,7 @@ class CactusSmilesConverter extends SmilesConverter
         $encoded = rawurlencode($name);
 
         // Check if we've got the name cached already.
-        $cached = $this->getIfCachedAndValid($encoded);
+        $cached = $this->getIfCached($encoded);
         if ($cached !== null) {
             return $cached;
         }

--- a/src/CactusSmilesConverter.php
+++ b/src/CactusSmilesConverter.php
@@ -12,7 +12,7 @@ use \GuzzleHttp\Client;
  * @since 06/08/2017
  * @package Avogadrio
  */
-class SmilesConverter
+class CactusSmilesConverter
 {
     /**
      * The compound name/SMILES cache database.

--- a/src/CactusSmilesConverter.php
+++ b/src/CactusSmilesConverter.php
@@ -15,7 +15,8 @@ use \GuzzleHttp\Client;
 class CactusSmilesConverter extends SmilesConverter
 {
     /**
-     * Initializes a new instance of a conversion service between compound names and SMILES strings.
+     * Initializes a new instance of a conversion service between compound names and SMILES strings that uses a
+     * dedicated lookup service.
      *
      * @param Database $db              the database in which to cache lookup results
      * @param SmilesConverter $fallback the conversion service to fall back to in case of error

--- a/src/SmilesConverter.php
+++ b/src/SmilesConverter.php
@@ -38,6 +38,17 @@ class SmilesConverter
     public function isCacheEnabled() {
         return $this->db !== null;
     }
+    
+    /**
+     * Attempts to fix any errors in a SMILES string and returns the result.
+     *
+     * @param string $smiles    the SMILES string to fix
+     * @return string           the fixed SMILES string
+     */
+    private static function fixSmiles($smiles) {
+        $output = str_replace('|', '', $smiles); // Zap vertical bars.
+        return $output;
+    }
 
     /**
      * Converts a compound name to SMILES notation.
@@ -54,7 +65,7 @@ class SmilesConverter
         if ($this->isCacheEnabled()) {
             $cachedSmiles = $this->db->get('smiles', 'name', $encoded);
             if ($cachedSmiles !== null) {
-                return $cachedSmiles;
+                return self::fixSmiles($cachedSmiles);
             }
         }
 
@@ -68,9 +79,9 @@ class SmilesConverter
             if ($this->isCacheEnabled()) {
                 $this->db->insert(['name' => $encoded, 'smiles' => $smiles]); // Cache name for future.
             }
-            return $smiles;
+            return self::fixSmiles($smiles);
         }
-
+        
         // Request failed.
         return null;
     }

--- a/src/SmilesConverter.php
+++ b/src/SmilesConverter.php
@@ -48,17 +48,6 @@ abstract class SmilesConverter
     }
 
     /**
-     * Attempts to fix any errors in a SMILES string and returns the result.
-     *
-     * @param string $smiles    the SMILES string to fix
-     * @return string           the fixed SMILES string
-     */
-    protected static function fixSmiles($smiles) {
-        $output = str_replace('|', '', $smiles); // Zap vertical bars.
-        return $output;
-    }
-
-    /**
      * Returns true if a given SMILES string is valid, otherwise returns false.
      *
      * @param string $smiles    the SMILES string to check
@@ -69,19 +58,27 @@ abstract class SmilesConverter
     }
 
     /**
-     * @param $name
-     * @return string
+     * Returns a cached SMILES string from its corresponding compound name, if present.
+     *
+     * @param string $name  the name of the compound to return
+     * @return string       the SMILES structure of the compound, or null if not found
      */
-    protected function getIfCachedAndValid($name) {
+    protected function getIfCached($name) {
         if ($this->isCacheEnabled()) {
             $cachedSmiles = $this->db->get('smiles', 'name', $name);
-            if ($cachedSmiles !== null && self::isValidSmiles($cachedSmiles)) {
+            if ($cachedSmiles !== null) {
                 return $cachedSmiles;
             }
         }
         return null;
     }
 
+    /**
+     * Caches a compound name against its corresponding SMILES string.
+     *
+     * @param string $name      the compound name
+     * @param string $smiles    the corresponding SMILES string
+     */
     protected function cache($name, $smiles) {
         if ($this->isCacheEnabled()) {
             $this->db->insert(['name' => $name, 'smiles' => $smiles]); // Cache name for future.

--- a/src/SmilesConverter.php
+++ b/src/SmilesConverter.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Avogadrio;
+
+use Condense\Database;
+
+/**
+ * Provides a conversion service between compound names and SMILES strings.
+ *
+ * @author Saul Johnson <saul.a.johnson@gmail.com>
+ * @since 27/08/2017
+ * @package Avogadrio
+ */
+abstract class SmilesConverter
+{
+    /**
+     * The compound name/SMILES cache database.
+     *
+     * @var Database
+     */
+    private $db;
+
+    /**
+     * The conversion service to fall back to in case of error.
+     *
+     * @var SmilesConverter
+     */
+    private $fallback;
+
+    /**
+     * Initializes a new instance of a conversion service between compound names and SMILES strings.
+     *
+     * @param Database $db              the database in which to cache lookup results
+     * @param SmilesConverter $fallback the conversion service to fall back to in case of error
+     */
+    protected function __construct($db, $fallback) {
+        $this->db = $db;
+        $this->fallback = $fallback;
+    }
+
+    /**
+     * Gets whether or not the API result cache is enabled.
+     *
+     * @return bool true if the cache is enabled, otherwise false
+     */
+    public function isCacheEnabled() {
+        return $this->db !== null;
+    }
+
+    /**
+     * Attempts to fix any errors in a SMILES string and returns the result.
+     *
+     * @param string $smiles    the SMILES string to fix
+     * @return string           the fixed SMILES string
+     */
+    protected static function fixSmiles($smiles) {
+        $output = str_replace('|', '', $smiles); // Zap vertical bars.
+        return $output;
+    }
+
+    /**
+     * Returns true if a given SMILES string is valid, otherwise returns false.
+     *
+     * @param string $smiles    the SMILES string to check
+     * @return bool             true if the string was valid, otherwise false
+     */
+    protected static function isValidSmiles($smiles) {
+        return preg_match('/^[a-zA-Z0-9@%=\\\\\/\[\]\.\+\-\_\*\(\)]+$/', $smiles) ? true : false;
+    }
+
+    /**
+     * @param $name
+     * @return string
+     */
+    protected function getIfCachedAndValid($name) {
+        if ($this->isCacheEnabled()) {
+            $cachedSmiles = $this->db->get('smiles', 'name', $name);
+            if ($cachedSmiles !== null && self::isValidSmiles($cachedSmiles)) {
+                return $cachedSmiles;
+            }
+        }
+        return null;
+    }
+
+    protected function cache($name, $smiles) {
+        if ($this->isCacheEnabled()) {
+            $this->db->insert(['name' => $name, 'smiles' => $smiles]); // Cache name for future.
+        }
+    }
+
+    /**
+     * Falls back to another SMILES conversion service.
+     *
+     * @param string $name  the compound name to convert
+     * @return null|string  the converted compound name or null if not found
+     */
+    protected function fallback($name) {
+        if ($this->fallback === null) {
+            return null;
+        }
+        return $this->fallback->nameToSmiles($name);
+    }
+
+    /**
+     * Converts a compound name to SMILES notation.
+     *
+     * @param string $name  the name of the compound
+     * @return null|string  the SMILES notation for the named compound or null if not found
+     */
+    public abstract function nameToSmiles($name);
+}

--- a/src/WikipediaSmilesConverter.php
+++ b/src/WikipediaSmilesConverter.php
@@ -34,7 +34,7 @@ class WikipediaSmilesConverter extends SmilesConverter
         $encoded = str_replace(' ', '_', $name);
 
         // Check if we've got the name cached already.
-        $cached = $this->getIfCachedAndValid($encoded);
+        $cached = $this->getIfCached($encoded);
         if ($cached !== null) {
             return $cached;
         }

--- a/src/WikipediaSmilesConverter.php
+++ b/src/WikipediaSmilesConverter.php
@@ -16,7 +16,8 @@ use pQuery;
 class WikipediaSmilesConverter extends SmilesConverter
 {
     /**
-     * Initializes a new instance of a conversion service between compound names and SMILES strings.
+     * Initializes a new instance of a conversion service between compound names and SMILES strings that scrapes SMILES
+     * strings from Wikipedia.
      *
      * @param Database $db              the database in which to cache lookup results
      * @param SmilesConverter $fallback the conversion service to fall back to in case of error

--- a/src/WikipediaSmilesConverter.php
+++ b/src/WikipediaSmilesConverter.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Avogadrio;
+
+use Condense\Database;
+use \GuzzleHttp\Client;
+use pQuery;
+
+/**
+ * Provides a conversion service between compound names and SMILES strings that scrapes SMILES strings from Wikipedia.
+ *
+ * @author Saul Johnson <saul.a.johnson@gmail.com>
+ * @since 27/08/2017
+ * @package Avogadrio
+ */
+class WikipediaSmilesConverter extends SmilesConverter
+{
+    /**
+     * Initializes a new instance of a conversion service between compound names and SMILES strings.
+     *
+     * @param Database $db              the database in which to cache lookup results
+     * @param SmilesConverter $fallback the conversion service to fall back to in case of error
+     */
+    public function __construct($db = null, $fallback = null) {
+        parent::__construct($db, $fallback);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function nameToSmiles($name)
+    {
+        // Sanitize name for URLs.
+        $encoded = str_replace(' ', '_', $name);
+
+        // Check if we've got the name cached already.
+        $cached = $this->getIfCachedAndValid($encoded);
+        if ($cached !== null) {
+            return $cached;
+        }
+
+        // Get Wikipedia page for compound.
+        $client = new Client();
+        $response = $client->request('GET', "https://en.wikipedia.org/wiki/$encoded");
+
+        // If there is a page.
+        if ($response->getStatusCode() === 200) {
+
+            // Parse page into DOM.
+            $page = $response->getBody()->getContents();
+            $dom = pQuery::parseStr($page);
+
+            // Get all hyperlinks.
+            $links = $dom->select('a');
+
+            // Look for the SMILES hyperlink.
+            foreach ($links as $link) {
+                if (strstr($link->text(), 'SMILES')) {
+                    $smiles = trim($link->parent->getNextSibling()->text()); // Get actual SMILES string.
+                    if (self::isValidSmiles($smiles)) {
+                        $this->cache($encoded, $smiles);
+                        return $smiles;
+                    }
+                }
+            }
+        }
+
+        return $this->fallback($name); // Fall back.
+    }
+}

--- a/web/index.php
+++ b/web/index.php
@@ -9,6 +9,7 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
 
 use Condense\Database;
 use Avogadrio\CactusSmilesConverter;
+use Avogadrio\WikipediaSmilesConverter;
 use Avogadrio\MoleculeRenderer;
 
 $app = new Silex\Application();
@@ -20,7 +21,7 @@ $app = new Silex\Application();
 $config = Spyc::YAMLLoad(__DIR__ . '/../config/config.yaml');
 
 // Services.
-$smilesConverter = new CactusSmilesConverter(new Database('names', __DIR__ . '/../db'));
+$smilesConverter = new CactusSmilesConverter(new Database('names', __DIR__ . '/../db'), new WikipediaSmilesConverter());
 $moleculeRenderer = new MoleculeRenderer($config['sourire_service']);
 
 $moleculeRenderer->setRenderChiralLabels(false); // Disable chiral labels.

--- a/web/index.php
+++ b/web/index.php
@@ -8,7 +8,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 
 use Condense\Database;
-use Avogadrio\SmilesConverter;
+use Avogadrio\CactusSmilesConverter;
 use Avogadrio\MoleculeRenderer;
 
 $app = new Silex\Application();
@@ -20,7 +20,7 @@ $app = new Silex\Application();
 $config = Spyc::YAMLLoad(__DIR__ . '/../config/config.yaml');
 
 // Services.
-$smilesConverter = new SmilesConverter(new Database('names', __DIR__ . '/../db'));
+$smilesConverter = new CactusSmilesConverter(new Database('names', __DIR__ . '/../db'));
 $moleculeRenderer = new MoleculeRenderer($config['sourire_service']);
 
 $moleculeRenderer->setRenderChiralLabels(false); // Disable chiral labels.

--- a/web/index.php
+++ b/web/index.php
@@ -5,7 +5,6 @@ require_once __DIR__ . '/../vendor/autoload.php';
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\HttpKernelInterface;
 
 use Condense\Database;
 use Avogadrio\CactusSmilesConverter;
@@ -21,7 +20,8 @@ $app = new Silex\Application();
 $config = Spyc::YAMLLoad(__DIR__ . '/../config/config.yaml');
 
 // Services.
-$smilesConverter = new CactusSmilesConverter(new Database('names', __DIR__ . '/../db'), new WikipediaSmilesConverter());
+$wikiSmilesConverter = new WikipediaSmilesConverter(new Database('names_wiki', __DIR__ . '/../db'));
+$smilesConverter = new CactusSmilesConverter(new Database('names', __DIR__ . '/../db'), $wikiSmilesConverter);
 $moleculeRenderer = new MoleculeRenderer($config['sourire_service']);
 
 $moleculeRenderer->setRenderChiralLabels(false); // Disable chiral labels.


### PR DESCRIPTION
Previously we were only using the service at `https://cactus.nci.nih.gov/chemical/structure` for SMILES lookups from compound names. This works pretty well, but sometimes we get SMILES back that contains vertical pipe `|` characters which breaks Sourire and won't render. These mainly seem to appear in organometallic compounds (ligand-related?)  and just don't play nice with the renderer.

To remedy this, we now fall back to attempting to scrape the SMILES from the compound's Wikipedia page. This means it was necessary to restructure SMILES lookup services to support the chain of responsibility pattern.