### PR TITLE
Fix molecule label rendering/rotation bug

### DIFF
--- a/src/coffee/main.coffee
+++ b/src/coffee/main.coffee
@@ -63,6 +63,7 @@ $(document).ready ->
     url = "/api/name/#{width}/#{height}/#{background}/#{foreground}/#{name}"
     qs = ""
     if customLabel != '' then qs += "label=#{customLabel}"
+    if qs != '' then qs += "&"
     if rotation != 0 then qs += "rotation=#{rotation}"
     return if qs == "" then url else url + "?" + qs
 
@@ -77,6 +78,7 @@ $(document).ready ->
     url = "/api/name/#{width}/#{height}/#{foreground}/#{name}"
     qs = ""
     if customLabel != '' then qs += "label=#{customLabel}"
+    if qs != '' then qs += "&"
     if rotation != 0 then qs += "rotation=#{rotation}"
     return if qs == "" then url else url + "?" + qs
 
@@ -92,6 +94,7 @@ $(document).ready ->
     url = "/api/smiles/#{width}/#{height}/#{background}/#{foreground}/#{smiles}"
     qs = ""
     if customLabel != '' then qs += "label=#{customLabel}"
+    if qs != '' then qs += "&"
     if rotation != 0 then qs += "rotation=#{rotation}"
     return if qs == "" then url else url + "?" + qs
 
@@ -106,6 +109,7 @@ $(document).ready ->
     url = "/api/smiles/#{width}/#{height}/#{foreground}/#{smiles}"
     qs = ""
     if customLabel != '' then qs += "label=#{customLabel}"
+    if qs != '' then qs += "&"
     if rotation != 0 then qs += "rotation=#{rotation}"
     return if qs == "" then url else url + "?" + qs
 


### PR DESCRIPTION
This PR fixes issue #37 opened by @douglasrizzo, and labels are now rendered properly when the molecule is rotated. As the label is handled by [the molecule rendering engine itself](https://github.com/ggasoftware/indigo) and rotation is applied as a post-processing step, labels *will* be rotated along with the molecule. This may be something that can be fixed in future by getting the rendering engine to perform the rotation instead.

![label_render_demo](https://user-images.githubusercontent.com/5577382/89742426-c0530200-da91-11ea-926a-d91bb8b48ec7.png)
